### PR TITLE
Cart debugging

### DIFF
--- a/components/ui/CartList/CartList.tsx
+++ b/components/ui/CartList/CartList.tsx
@@ -29,7 +29,8 @@ const CartList = ({ cookieCart, ethUsd, setCookie }: Props) => {
         const externalCallEth = utils.formatEther(extCallValue)
 
         const index = cookieCart.findIndex(
-          (p: ProductCart) => p.productId == productId
+          (p: ProductCart) =>
+            p.productId == productId && p.slicerAddress == slicerAddress
         )
 
         const handleRemove = () => {

--- a/components/ui/FloatingCart/FloatingCart.tsx
+++ b/components/ui/FloatingCart/FloatingCart.tsx
@@ -23,6 +23,7 @@ type Props = {
 }
 
 const FloatingCart = ({ cookieCart, success, setSuccess }: Props) => {
+  console.log(cookieCart, "cookieCart")
   const { setPurchases, purchases, setModalView, account } = useAppContext()
   const { data: signer } = useSigner()
   const addRecentTransaction = useAddRecentTransaction()

--- a/components/ui/FloatingCart/FloatingCart.tsx
+++ b/components/ui/FloatingCart/FloatingCart.tsx
@@ -23,7 +23,6 @@ type Props = {
 }
 
 const FloatingCart = ({ cookieCart, success, setSuccess }: Props) => {
-  console.log(cookieCart, "cookieCart")
   const { setPurchases, purchases, setModalView, account } = useAppContext()
   const { data: signer } = useSigner()
   const addRecentTransaction = useAddRecentTransaction()

--- a/lib/handleUpdateCart.ts
+++ b/lib/handleUpdateCart.ts
@@ -39,7 +39,8 @@ const handleUpdateCart = async (
   if (newCookies.length != 0 && productCart) {
     const quantity = productCart.quantity + newQuantity
     const index = newCookies.findIndex(
-      (p: ProductCart) => p.productId == productId
+      (p: ProductCart) =>
+        p.productId == productId && p.slicerAddress == slicerAddress
     )
     if (quantity > 0) {
       newCookies[index] = {

--- a/pages/slicer/[id]/index.tsx
+++ b/pages/slicer/[id]/index.tsx
@@ -29,7 +29,6 @@ import formatCalldata from "@utils/formatCalldata"
 import client from "@utils/apollo-client"
 import { gql } from "@apollo/client"
 import { sliceCore } from "@lib/initProvider"
-import Link from "next/link"
 
 export type NewImage = { url: string; file: File }
 export type SlicerAttributes = {

--- a/pages/slicer/[id]/index.tsx
+++ b/pages/slicer/[id]/index.tsx
@@ -29,6 +29,7 @@ import formatCalldata from "@utils/formatCalldata"
 import client from "@utils/apollo-client"
 import { gql } from "@apollo/client"
 import { sliceCore } from "@lib/initProvider"
+import Link from "next/link"
 
 export type NewImage = { url: string; file: File }
 export type SlicerAttributes = {
@@ -409,7 +410,8 @@ export async function getStaticProps(context: GetStaticPropsContext) {
       slicerInfo,
       products,
       subgraphDataPayees: subgraphData?.slicer?.payees,
-      subgraphDataProducts: subgraphData?.slicer?.products
+      subgraphDataProducts: subgraphData?.slicer?.products,
+      key: slicerInfo.id
     },
     revalidate: 300
   }


### PR DESCRIPTION
### Slicer info doesn’t update 

_How to reproduce:_ 

→ Add a product to cart 

→ change slicer 

→ click on the added product on cart 

→ header data not updated after redirect to slicer show page

_Fix:_ Returning a key prop form GetStaticProps

### Cookie Cart - Items shuffled

_How to reproduce:_  

→ Add Product #1 to cart from Slicer #34  

→ Go to slicer #35 and add Product #1 to cart

→ Update product #1 (slicer#35) quantity

→ Updated wrong product

_Fix:_ Check both productID and SlicerAddress before updating quantity, not just the productID

### Delete product from cart

_How to reproduce:_ 

→ Add to cart two products with same ID from different slicers 

→ delete the last added 

→ first added deleted

_Fix:_ Check both productID and SlicerAddress before deleting, not just the productID